### PR TITLE
Issues with direction and kiloWatt and Watt.

### DIFF
--- a/dbus-enphase-envoy/dbus-enphase-envoy.py
+++ b/dbus-enphase-envoy/dbus-enphase-envoy.py
@@ -647,15 +647,15 @@ class DbusEnphaseEnvoyPvService:
             logging.info('--> DbusEnphaseEnvoyPvService->_update(): got exit signal')
             sys.exit()
 
-        self._dbusservice['/Ac/Power'] =  round(pv_power, 2)
+        self._dbusservice['/Ac/Power'] =  round(pv_power*-1000, 2)
         self._dbusservice['/Ac/Current'] = round(pv_current, 2)
         self._dbusservice['/Ac/Voltage'] = round(pv_voltage, 2)
-        #self._dbusservice['/Ac/Energy/Forward'] = round(pv_forward/1000, 2)
+        #self._dbusservice['/Ac/Energy/Forward'] = round(pv_forward*-1000, 2)
 
-        self._dbusservice['/Ac/L1/Power'] = round(pv_L1_power, 2)
+        self._dbusservice['/Ac/L1/Power'] = round(pv_power*-1000, 2)
         self._dbusservice['/Ac/L1/Current'] = round(pv_L1_current, 2)
         self._dbusservice['/Ac/L1/Voltage'] = round(pv_L1_voltage, 2)
-        #self._dbusservice['/Ac/L1/Energy/Forward'] = round(pv_L1_forward/1000, 2)
+        #self._dbusservice['/Ac/L1/Energy/Forward'] = round(pv_L1_forward*-1000, 2)
 
         #self._dbusservice['/StatusCode'] = 7
 


### PR DESCRIPTION
At first thanks for the great work! Looks really good.  Unfortunately I experienced some issues. In my case only the `pv_L1_voltage` and `pv_power` field got assigned. To make it work for now I changed some variables. I also had to change the direction and convert from kWatt to Watt `(*-1000)` to make the flow being visualized in the correct direction.


Debug info: 
`2022-11-23 11:09:46.528134500 DEBUG:root:{'Mgmt/ProcessName': dbus.String('/data/etc/dbus-enphase-envoy/dbus-enphase-envoy.py', variant_level=1), 'Mgmt/ProcessVersion': dbus.String('Unkown version, and running on Python 3.8.13', variant_level=1), 'Mgmt/Connection': dbus.String('Enphase PV service', variant_level=1), 'DeviceInstance': dbus.Int32(61, variant_level=1), 'ProductId': dbus.Int32(65535, variant_level=1), 'ProductName': dbus.String('Enphase PV', variant_level=1), 'CustomName': dbus.String('Enphase PV', variant_level=1), 'FirmwareVersion': dbus.Double(0.1, variant_level=1), 'HardwareVersion': dbus.Int32(0, variant_level=1), 'Connected': dbus.Int32(1, variant_level=1), 'Latency': dbus.Array([], signature=dbus.Signature('i'), variant_level=1), 'Position': dbus.Int32(0, variant_level=1), 'StatusCode': dbus.Int32(0, variant_level=1), 'Ac/Power': dbus.Double(-0.2, variant_level=1), 'Ac/Current': dbus.Double(0.43, variant_level=1), 'Ac/Voltage': dbus.Double(237.4, variant_level=1), 'Ac/L1/Power': dbus.Double(-0.0, variant_level=1), 'Ac/L1/Current': dbus.Double(0.0, variant_level=1), 'Ac/L1/Voltage': dbus.Double(230.55, variant_level=1), 'Ac/MaxPower': dbus.Int32(700, variant_level=1), 'Ac/Position': dbus.Int32(0, variant_level=1), 'Ac/StatusCode': dbus.Int32(0, variant_level=1), 'UpdateIndex': dbus.Int32(216, variant_level=1)}
2022-11-23 11:09:46.624459500 DEBUG:root:_get_value_handler called for /
2022-11-23 11:09:46.627050500 DEBUG:root:{'Mgmt/ProcessName': dbus.String('/data/etc/dbus-enphase-envoy/dbus-enphase-envoy.py', variant_level=1), 'Mgmt/ProcessVersion': dbus.String('Unkown version, and running on Python 3.8.13', variant_level=1), 'Mgmt/Connection': dbus.String('Enphase PV service', variant_level=1), 'DeviceInstance': dbus.Int32(61, variant_level=1), 'ProductId': dbus.Int32(65535, variant_level=1), 'ProductName': dbus.String('Enphase PV', variant_level=1), 'CustomName': dbus.String('Enphase PV', variant_level=1), 'FirmwareVersion': dbus.Double(0.1, variant_level=1), 'HardwareVersion': dbus.Int32(0, variant_level=1), 'Connected': dbus.Int32(1, variant_level=1), 'Latency': dbus.Array([], signature=dbus.Signature('i'), variant_level=1), 'Position': dbus.Int32(0, variant_level=1), 'StatusCode': dbus.Int32(0, variant_level=1), 'Ac/Power': dbus.Double(-0.2, variant_level=1), 'Ac/Current': dbus.Double(0.43, variant_level=1), 'Ac/Voltage': dbus.Double(237.4, variant_level=1), 'Ac/L1/Power': dbus.Double(-0.0, variant_level=1), 'Ac/L1/Current': dbus.Double(0.0, variant_level=1), 'Ac/L1/Voltage': dbus.Double(230.55, variant_level=1), 'Ac/MaxPower': dbus.Int32(700, variant_level=1), 'Ac/Position': dbus.Int32(0, variant_level=1), 'Ac/StatusCode': dbus.Int32(0, variant_level=1), 'UpdateIndex': dbus.Int32(216, variant_level=1)}
2022-11-23 11:09:46.633138500 DEBUG:root:_get_value_handler called for /
2022-11-23 11:09:46.637675500 DEBUG:root:{'Mgmt/ProcessName': '/data/etc/dbus-enphase-envoy/dbus-enphase-envoy.py', 'Mgmt/ProcessVersion': 'Unkown version, and running on Python 3.8.13', 'Mgmt/Connection': 'Enphase PV service', 'DeviceInstance': '61', 'ProductId': '0xFFFF', 'ProductName': 'Enphase PV', 'CustomName': 'Enphase PV', 'FirmwareVersion': '0.1', 'HardwareVersion': '0', 'Connected': '1', 'Latency': '---', 'Position': '0', 'StatusCode': '0', 'Ac/Power': '-0.2W', 'Ac/Current': '0.43A', 'Ac/Voltage': '237.4V', 'Ac/L1/Power': '-0.0W', 'Ac/L1/Current': '0.0A', 'Ac/L1/Voltage': '230.55V', 'Ac/MaxPower': '700W', 'Ac/Position': '0', 'Ac/StatusCode': '0', 'UpdateIndex': '216'}
2022-11-23 11:09:47.077078500 INFO:root:PV: -0.3 W - 237.4 V - 0.4 A
2022-11-23 11:09:47.078036500 INFO:root:|- L2: -0.1 W - 2.3 V - 0.3 A
2022-11-23 11:09:47.105416500 INFO:root:|- L3: -0.1 W - 4.6 V - 0.1 A
2022-11-23 11:09:48.094012500 INFO:root:PV: -0.3 W - 237.5 V - 0.4 A
2022-11-23 11:09:48.094020500 INFO:root:|- L2: -0.1 W - 2.3 V - 0.3 A
2022-11-23 11:09:48.094023500 INFO:root:|- L3: -0.2 W - 4.6 V - 0.1 A
2022-11-23 11:09:49.106010500 INFO:root:PV: -0.4 W - 237.6 V - 0.4 A
2022-11-23 11:09:49.107178500 INFO:root:|- L2: -0.1 W - 2.3 V - 0.3 A
2022-11-23 11:09:49.108124500 INFO:root:|- L3: -0.2 W - 4.6 V - 0.1 A
2022-11-23 11:09:50.091766500 INFO:root:PV: -0.2 W - 237.6 V - 0.4 A
2022-11-23 11:09:50.091776500 INFO:root:|- L2: -0.1 W - 2.3 V - 0.3 A
2022-11-23 11:09:50.091779500 INFO:root:|- L3: -0.2 W - 4.6 V - 0.1 A
2022-11-23 11:09:51.102739500 INFO:root:PV: -0.3 W - 237.6 V - 0.4 A
2022-11-23 11:09:51.102747500 INFO:root:|- L2: -0.1 W - 2.3 V - 0.3 A
2022-11-23 11:09:51.102750500 INFO:root:|- L3: -0.1 W - 4.6 V - 0.1 A`

Screenshots after changes:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/54217714/203536777-78cfe089-6284-4298-9169-e4ac80c913f4.png">
<img width="875" alt="image" src="https://user-images.githubusercontent.com/54217714/203536874-46452085-b1d0-465f-a9b0-6fb014122c05.png">
